### PR TITLE
Move querybuilder menu items to main navigation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,7 +20,6 @@ export const routes: Routes = [
     canLoad: [RoleGuard],
     data: {
       navId: 'querybuilder',
-      roles: ['CODEX_USER'],
     },
     loadChildren: () =>
       import(

--- a/src/app/core/constants/navigation.ts
+++ b/src/app/core/constants/navigation.ts
@@ -7,21 +7,15 @@ export const mainNavItems: INavItem[] = [
     translationKey: 'NAVIGATION.DASHBOARD',
   },
   {
-    routeTo: 'querybuilder',
+    routeTo: 'querybuilder/editor',
     icon: 'dna',
-    translationKey: 'NAVIGATION.QUERYBUILDER',
-    tabNav: [
-      {
-        routeTo: 'querybuilder/editor',
-        id: 'editor',
-        translationKey: 'NAVIGATION.QUERYBUILDER_EDITOR',
-      },
-      {
-        routeTo: 'querybuilder/overview',
-        id: 'overview',
-        translationKey: 'NAVIGATION.QUERYBUILDER_OVERVIEW',
-      },
-    ],
+    translationKey: 'NAVIGATION.QUERYBUILDER_EDITOR',
+  },
+  {
+    routeTo: 'querybuilder/overview',
+    roles: ['CODEX_USER'],
+    icon: 'bars',
+    translationKey: 'NAVIGATION.QUERYBUILDER_OVERVIEW',
   },
 ]
 

--- a/src/app/modules/querybuilder/components/querybuilder-editor/querybuilder-editor.component.scss
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/querybuilder-editor.component.scss
@@ -3,5 +3,5 @@
 }
 
 .container {
-  margin: 0 0 0.5em 0;
+  margin: 1em 0 0.5em 0;
 }

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.html
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.html
@@ -23,12 +23,7 @@
       </button>
     </mat-form-field>
     <div fxFlex="20">
-      <button
-        class="button-tree-view"
-        type="button"
-        mat-icon-button
-        (click)="switchSearchMode($event)"
-      >
+      <button class="button-tree-view" type="button" mat-icon-button (click)="switchSearchMode()">
         <fa-icon size="2x" icon="project-diagram"></fa-icon>
       </button>
     </div>
@@ -55,6 +50,7 @@
     [text]="search"
     [critType]="critType"
     [query]="query"
+    (switchSearchMode)="switchSearchMode()"
     (closeOverlay)="closeOverlay($event)"
   >
   </num-search-text-overlay-content>

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.spec.ts
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.spec.ts
@@ -93,7 +93,7 @@ describe('SearchInputComponent', () => {
       component.search = ''
       component.isOverlayOpen = false
 
-      component.switchSearchMode({} as MouseEvent)
+      component.switchSearchMode()
 
       expect(component.searchMode).toBe('tree')
       expect(component.isOverlayOpen).toBe(true)
@@ -103,7 +103,7 @@ describe('SearchInputComponent', () => {
       component.searchMode = 'tree'
       component.search = 'abc'
 
-      component.switchSearchMode({} as MouseEvent)
+      component.switchSearchMode()
 
       expect(component.searchMode).toBe('text')
       expect(component.isOverlayOpen).toBe(true)
@@ -113,7 +113,7 @@ describe('SearchInputComponent', () => {
       component.searchMode = 'tree'
       component.search = ''
 
-      component.switchSearchMode({} as MouseEvent)
+      component.switchSearchMode()
 
       expect(component.searchMode).toBe('text')
       expect(component.isOverlayOpen).toBe(false)
@@ -127,6 +127,7 @@ describe('SearchInputComponent', () => {
 
       expect(component.search).toBe('')
       expect(component.isOverlayOpen).toBe(false)
+      expect(component.searchMode).toBe('text')
     })
 
     it('should not delete search text', () => {
@@ -137,6 +138,7 @@ describe('SearchInputComponent', () => {
 
       expect(component.search).toBe('abc')
       expect(component.isOverlayOpen).toBe(false)
+      expect(component.searchMode).toBe('text')
     })
 
     it('should initialize position on the right ("inclusion")', () => {
@@ -176,7 +178,7 @@ describe('SearchInputComponent', () => {
         },
         getTerminolgyEntrySearchResult(
           catId: string,
-          search: string
+          search: string,
         ): Observable<Array<TerminologyEntry>> {
           return of(new MockBackendDataProvider().getTerminolgyEntrySearchResult(catId, search))
         },
@@ -194,7 +196,7 @@ describe('SearchInputComponent', () => {
 
       // trigger the click
       const overlayContent = document.querySelector(
-        '.cdk-overlay-container num-search-text-overlay-content'
+        '.cdk-overlay-container num-search-text-overlay-content',
       )
       overlayContent.dispatchEvent(new Event('closeOverlay'))
 
@@ -206,7 +208,8 @@ describe('SearchInputComponent', () => {
       monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin> {
         return of({} as FocusOrigin)
       },
-      stopMonitoring(element: HTMLElement): void {},
+      stopMonitoring(element: HTMLElement): void {
+      },
     } as FocusMonitor
 
     it('overlay should remain closed when input field is not focused', () => {

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.ts
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-input/search-input.component.ts
@@ -56,7 +56,9 @@ export class SearchInputComponent implements OnInit, OnDestroy {
   @ViewChild(CdkConnectedOverlay, { static: true })
   public connectedOverlay: CdkConnectedOverlay
 
-  constructor(private focusMonitor: FocusMonitor) {}
+  constructor(private focusMonitor: FocusMonitor) {
+    this.resetOverlayProperties()
+  }
 
   ngOnInit(): void {
     this.initPositionStrategy()
@@ -122,7 +124,7 @@ export class SearchInputComponent implements OnInit, OnDestroy {
     return this.critType.toUpperCase()
   }
 
-  switchSearchMode($event: MouseEvent): void {
+  switchSearchMode(): void {
     this.searchMode = this.searchMode === 'tree' ? 'text' : 'tree'
     if (this.searchMode === 'tree') {
       this.isOverlayOpen = true
@@ -135,7 +137,12 @@ export class SearchInputComponent implements OnInit, OnDestroy {
     if (mode === 'text') {
       this.search = ''
     }
+    this.resetOverlayProperties()
+  }
+
+  private resetOverlayProperties(): void {
     this.isOverlayOpen = false
+    this.searchMode = 'text'
   }
 }
 

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.html
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.html
@@ -1,6 +1,19 @@
 <div class="container">
-  <num-search-text-header [categories]="categories" (switchCategory)="readTextData($event)">
+  <num-search-text-header
+    *ngIf="text"
+    [categories]="categories"
+    (switchCategory)="readTextData($event)"
+  >
   </num-search-text-header>
+
+  <div *ngIf="!text" fxLayout="row" fxLayoutAlign="center center" class="hint-empty-text">
+    <div>
+      Geben Sie ein Suchkriterium ein oder öffen sie die Übersicht der Kategorien
+      <button class="button-tree-view" type="button" mat-icon-button (click)="doSwitchSearchMode()">
+        <fa-icon icon="project-diagram"></fa-icon>
+      </button>
+    </div>
+  </div>
 
   <div *ngIf="text" class="search-results">
     <div *ngFor="let termEntry of resultList">

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.scss
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.scss
@@ -9,3 +9,12 @@
   max-height: 40vh;
   overflow-y: auto;
 }
+
+.hint-empty-text {
+  width: 100%;
+  height: 9em;
+}
+
+.button-tree-view {
+  background-color: var(--num-color--accent-300);
+}

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.spec.ts
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.spec.ts
@@ -112,4 +112,10 @@ describe('SerachTextOverlayContentComponent', () => {
     expect(component.closeOverlay.emit).toHaveBeenCalledWith('text')
     expect(component.dialog.open).toHaveBeenCalledWith(EnterCriterionListComponent, dialogConfig)
   })
+
+  it('should fire storeQuery event', () => {
+    spyOn(component.switchSearchMode, 'emit')
+    component.doSwitchSearchMode()
+    expect(component.switchSearchMode.emit).toBeCalled()
+  })
 })

--- a/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.ts
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/search/search-text-overlay-content/search-text-overlay-content.component.ts
@@ -26,6 +26,9 @@ export class SearchTextOverlayContentComponent implements OnInit, OnChanges, OnD
   @Output()
   closeOverlay = new EventEmitter<SearchMode>()
 
+  @Output()
+  switchSearchMode = new EventEmitter<void>()
+
   @Input()
   text: string
 
@@ -86,5 +89,9 @@ export class SearchTextOverlayContentComponent implements OnInit, OnChanges, OnD
 
     this.dialog.open(EnterCriterionListComponent, dialogConfig)
     this.closeOverlay.emit('text')
+  }
+
+  doSwitchSearchMode(): void {
+    this.switchSearchMode.emit()
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -16,10 +16,9 @@
     }
   },
   "NAVIGATION": {
-    "DASHBOARD": "Übersicht",
-    "QUERYBUILDER": "Abfragen",
-    "QUERYBUILDER_EDITOR": "Abfrage erstellen",
-    "QUERYBUILDER_OVERVIEW": "Übersicht",
+    "DASHBOARD": "Dashboard",
+    "QUERYBUILDER_EDITOR": "Neue Abfrage",
+    "QUERYBUILDER_OVERVIEW": "Meine Abfragen",
     "SIGNOUT": "Abmelden"
   },
   "QUERYBUILDER": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -17,9 +17,8 @@
   },
   "NAVIGATION": {
     "DASHBOARD": "Dashboard",
-    "QUERYBUILDER": "Queries",
-    "QUERYBUILDER_EDITOR": "Create query",
-    "QUERYBUILDER_OVERVIEW": "Overview",
+    "QUERYBUILDER_EDITOR": "New query",
+    "QUERYBUILDER_OVERVIEW": "My queries",
     "SIGNOUT": "Sign out"
   },
   "QUERYBUILDER": {


### PR DESCRIPTION
- Having two items in navbar for querybuilder
- show hint text when focus on empty search input field