### PR TITLE
bugfix: set correct time in timerestrictions

### DIFF
--- a/src/app/modules/querybuilder/components/querybuilder-editor/display/display-time-restriction/display-time-restriction.component.html
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/display/display-time-restriction/display-time-restriction.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="timeRestriction" class="container">
-  <div *ngIf="timeRestriction.minDate || timeRestriction.maxDate">
+<div *ngIf="timeRestriction">
+  <div *ngIf="timeRestriction.minDate || timeRestriction.maxDate" class="container">
     <span *ngIf="timeRestriction.tvpe !== timeRestrictionType.BETWEEN">
       {{ 'QUERYBUILDER.EDIT.TIMERESTRICTION.' + timeRestriction.tvpe | translate }}
       {{ getDateFormatted(timeRestriction.minDate) }}

--- a/src/app/modules/querybuilder/components/querybuilder-editor/display/display-time-restriction/display-time-restriction.component.scss
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/display/display-time-restriction/display-time-restriction.component.scss
@@ -1,9 +1,5 @@
 .container {
   margin: 0.3em 0;
-
-  background-color: var(--num-color--accent-200);
-}
-
-.container > div {
   padding: 0.1em 0.3em;
+  background-color: var(--num-color--accent-200);
 }

--- a/src/app/modules/querybuilder/controller/ApiTranslator.ts
+++ b/src/app/modules/querybuilder/controller/ApiTranslator.ts
@@ -151,6 +151,8 @@ export class ApiTranslator {
           attribute.value = undefined
         }
       })
+    } else {
+      criterion.attributeFilters = undefined
     }
   }
 
@@ -169,46 +171,55 @@ export class ApiTranslator {
             criterion.timeRestriction.beforeDate = undefined
             break
           }
-          case TimeRestrictionType.AFTER_OR_AT: {
+          /*case TimeRestrictionType.AFTER_OR_AT: {
             criterion.timeRestriction.afterDate.setDate(minTemp.getDate())
             criterion.timeRestriction.beforeDate = undefined
             break
-          }
+          }*/
           case TimeRestrictionType.BEFORE: {
             criterion.timeRestriction.beforeDate.setDate(minTemp.getDate() - 1)
             criterion.timeRestriction.afterDate = undefined
             break
           }
-          case TimeRestrictionType.BEFORE_OR_AT: {
+          /*case TimeRestrictionType.BEFORE_OR_AT: {
             criterion.timeRestriction.beforeDate.setDate(minTemp.getDate())
             criterion.timeRestriction.afterDate = undefined
             break
-          }
+          }*/
           case TimeRestrictionType.AT: {
             criterion.timeRestriction.beforeDate.setDate(minTemp.getDate())
             criterion.timeRestriction.afterDate.setDate(minTemp.getDate())
             break
           }
-          case TimeRestrictionType.NOT_AT: {
+          /*case TimeRestrictionType.NOT_AT: {
             criterion.timeRestriction.beforeDate.setDate(minTemp.getDate() - 1)
             criterion.timeRestriction.afterDate.setDate(minTemp.getDate() + 1)
             break
-          }
+          }*/
           case TimeRestrictionType.BETWEEN: {
             if (criterion.timeRestriction.maxDate) {
               criterion.timeRestriction.beforeDate.setDate(maxTemp.getDate())
               criterion.timeRestriction.afterDate.setDate(minTemp.getDate())
             } else {
-              criterion.timeRestriction.beforeDate = undefined
-              criterion.timeRestriction.afterDate = undefined
+              criterion.timeRestriction = undefined
             }
             break
           }
         }
+      } else {
+        criterion.timeRestriction = undefined
       }
-      criterion.timeRestriction.tvpe = undefined
-      criterion.timeRestriction.minDate = undefined
-      criterion.timeRestriction.maxDate = undefined
+      if (criterion.timeRestriction) {
+        criterion.timeRestriction.tvpe = undefined
+        criterion.timeRestriction.minDate = undefined
+        criterion.timeRestriction.maxDate = undefined
+        if (criterion.timeRestriction.beforeDate) {
+          criterion.timeRestriction.beforeDate.setHours(24, 59, 59, 999)
+        }
+        if (criterion.timeRestriction.afterDate) {
+          criterion.timeRestriction.afterDate.setHours(1, 0, 0, 0)
+        }
+      }
     }
   }
 }

--- a/src/app/modules/querybuilder/model/api/query/timerestriction.ts
+++ b/src/app/modules/querybuilder/model/api/query/timerestriction.ts
@@ -13,9 +13,9 @@ export class TimeRestriction {
 export enum TimeRestrictionType {
   BETWEEN = 'BETWEEN',
   AT = 'AT',
-  NOT_AT = 'NOT_AT',
+  // NOT_AT = 'NOT_AT',
   BEFORE = 'BEFORE',
-  BEFORE_OR_AT = 'BEFORE_OR_AT',
+  // BEFORE_OR_AT = 'BEFORE_OR_AT',
   AFTER = 'AFTER',
-  AFTER_OR_AT = 'AFTER_OR_AT',
+  // AFTER_OR_AT = 'AFTER_OR_AT',
 }


### PR DESCRIPTION
bugfix: removed empty timerestrictions and empty attributefilters
deactivate 3 timerestriction options (AFTER_OR_AT, BEFORE_OR_AT, NOT_AT)